### PR TITLE
[Fix #4] : Handles edge cases for `run(duration) ≤ 0`

### DIFF
--- a/brian2wasm/device.py
+++ b/brian2wasm/device.py
@@ -207,6 +207,11 @@ class WASMStandaloneDevice(CPPStandaloneDevice):
 
     def network_run(self, net, duration, report=None, report_period=10*second,
                     namespace=None, profile=None, level=0, **kwds):
+        if duration < 0:
+            raise ValueError(
+                f"Function 'run' expected a non-negative duration but got '{duration}'"
+            )
+
         self.networks.add(net)
         if kwds:
             logger.warn(('Unsupported keyword argument(s) provided for run: '

--- a/brian2wasm/templates/objects.cpp
+++ b/brian2wasm/templates/objects.cpp
@@ -285,14 +285,11 @@ void _write_arrays()
 	outfile_{{varname}}.open(results_dir + "{{get_array_filename(var)}}", ios::binary | ios::out);
 	if(outfile_{{varname}}.is_open())
 	{
-        if (! {{varname}}.empty() )
-        {
 			outfile_{{varname}}.write(reinterpret_cast<char*>(&{{varname}}[0]), {{varname}}.size()*sizeof({{varname}}[0]));
 		    outfile_{{varname}}.close();
 			EM_ASM({
 				add_results('{{var.owner.name}}', '{{var.name}}', '{{c_data_type(var.dtype)}}', UTF8ToString($0) + '{{get_array_filename(var)}}', $1);
 			}, results_dir.c_str(), {{varname}}.size());
-		}
 	} else
 	{
 		std::cout << "Error writing output file for {{varname}}." << endl;


### PR DESCRIPTION
Fixes #4 

For `duration < 0`:
- Raises a ValueError in `wasm_standalone`

For `duration == 0`:
- Allows empty arrays to be passed to JS.

Tested with all examples in the brian2wasm repository, and it works correctly.