### PR TITLE
[Fix #7] : Remove redundant condition for `char` from `pre.js`

### DIFF
--- a/brian2wasm/templates/pre.js
+++ b/brian2wasm/templates/pre.js
@@ -8,7 +8,7 @@ function add_results(owner, varname, dtype, array_filename, n1, n2 = 0) {
        array_class = Float64Array;
     } else if (dtype == 'float') {
         array_class = Float32Array;
-    } else if (dtype == 'int32_t' || dtype == 'char') {
+    } else if (dtype == 'int32_t') {
         array_class = Int32Array;
     } else if (dtype == 'int64_t') {
         array_class = BigInt64Array;


### PR DESCRIPTION
Fixes #7 

`char` data-types are initialised with `Uint8Array` and not `Int32Array`

Changed `if` condition from 
```js
else if (dtype == 'int32_t' || dtype == 'char')
```

to
```js
else if (dtype == 'int32_t')
```